### PR TITLE
Update libplist in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ AC_PROG_LIBTOOL
 
 # Checks for libraries.
 PKG_CHECK_MODULES(libimobiledevice, libimobiledevice-1.0 >= 1.2.0)
-PKG_CHECK_MODULES(libplist, libplist >= 0.15)
+PKG_CHECK_MODULES(libplist, libplist-2.0 >= 0.15)
 PKG_CHECK_MODULES(libzip, libzip >= 0.10)
 
 # Checks for header files.


### PR DESCRIPTION
I wasn't able to build `idevicelocation` due to an inability for `configure.sh` to find `libplist` that was installed through Homebrew:

```
configure: error: Package requirements (libplist >= 0.15) were not met:

No package 'libplist' found

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.
```

```
$ brew list libplist 
/usr/local/Cellar/libplist/2.2.0/bin/plistutil
/usr/local/Cellar/libplist/2.2.0/include/plist/ (14 files)
/usr/local/Cellar/libplist/2.2.0/lib/libplist++-2.0.3.dylib
/usr/local/Cellar/libplist/2.2.0/lib/libplist-2.0.3.dylib
/usr/local/Cellar/libplist/2.2.0/lib/pkgconfig/ (2 files)
/usr/local/Cellar/libplist/2.2.0/lib/ (4 other files)
/usr/local/Cellar/libplist/2.2.0/share/man/man1/plistutil.1
```

This appears to be because the `libplist` binary was recently renamed: https://github.com/libimobiledevice/libplist/issues/163, https://github.com/libimobiledevice/libplist/commit/137716df3f197a7184c1fba88fcb30480dafd6e0. Updating the module name then allows `idevicelocation` to be built successfully with the latest version of `libplist`.